### PR TITLE
more robust handling of having multiple instances of the diagram editor opened (different diagrams in different tabs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 ﻿# trilium-drawio
-## version: 0.5 for trilium > 0.62.4
+## version: 0.6 for trilium > 0.62.4
+
 ## update
-1. Fixed the bug where large files can only be displayed after refreshing when they are closed
-2. Use light theme by default
+1. fixed bug that blocked editing more than one draw.io diagram in one session
+2. improved handling of dark theme for note previews
 ## Draw.io is a JavaScript, client-side editor for general diagramming and whiteboarding. **This widget allows you to use drawio drawing in trilium.**
 ## Installation
 1. Create a code note of type JS Frontend with the contents of `trilium-drawio.js` and the label `#widget`

--- a/trilium-drawio.js
+++ b/trilium-drawio.js
@@ -1,10 +1,10 @@
 /*
 trilium-drawio
 https://github.com/SiriusXT/trilium-drawio
-version:0.5
+version:0.6
 */
 
-var defaultTheme = "0" //0:light;1:dark;,2:Follow software theme styles
+var defaultTheme = "2" //0:light;1:dark;,2:Follow software theme styles
 
 var currentNoteId;
 var themeStyle = getComputedStyle(document.documentElement).getPropertyValue('--theme-style');
@@ -14,7 +14,22 @@ var editor = 'https://embed.diagrams.net/?embed=1&ui=min&spin=1&proto=json&confi
 var id_svg_dict = {}
 var noteId = ''
 
+
+
 function edit(noteId) {
+
+  const $wrapper = $('div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper');
+
+  // Guard: if editor already open in this note, don't add another one
+  if ($wrapper.find('div.iframe-drawio').length > 0) {
+    return;
+  }
+
+  // (optional extra hardening: also kill any stray fullscreen editor)
+  if ($('body > div.iframe-drawio').length > 0) {
+    $('body > div.iframe-drawio').remove();
+  }
+
 	$('div.component.note-split:not(.hidden-ext) div.component.scrolling-container div.note-detail.component div.note-detail-image-wrapper').off("click");
 
 	var svg = id_svg_dict[noteId];
@@ -152,20 +167,26 @@ function edit(noteId) {
 };
 
 
+
 function addClick(noteId, autoEdit) {
-	var $img = $('div.component.note-split:not(.hidden-ext) div.component.scrolling-container div.note-detail.component img.note-detail-image-view');
-	if (!$img.hasClass('dark') && !$img.hasClass('light')) {
-		$('div.component.note-split:not(.hidden-ext) div.component.scrolling-container div.note-detail.component div.note-detail-image-wrapper').off("click");
-		$('div.component.note-split:not(.hidden-ext) div.component.scrolling-container div.note-detail.component div.note-detail-image-wrapper').click(noteId, function () {
-			edit(noteId);
-		});
-	}
-	if (themeStyle.indexOf('dark') >= 0) { $img.addClass('dark'); }
-	else if (themeStyle.indexOf('light') >= 0) { $img.addClass('light'); }
-	if (autoEdit) {
-		edit(noteId);
-	}
+  const $wrapper = $('div.component.note-split:not(.hidden-ext) div.component.scrolling-container div.note-detail.component div.note-detail-image-wrapper');
+  const $img = $('div.component.note-split:not(.hidden-ext) div.component.scrolling-container div.note-detail.component img.note-detail-image-view');
+
+  // Always (re)bind
+  $wrapper.off("click.drawio");
+  $wrapper.on("click.drawio", function () { edit(noteId); });
+
+  if (themeStyle.indexOf('dark') >= 0) {
+    $img.addClass('dark');
+  } else if (themeStyle.indexOf('light') >= 0) {
+    $img.addClass('light');
+  }
+
+  if (autoEdit) {
+    edit(noteId);
+  }
 }
+
 
 class DrawiIo extends api.NoteContextAwareWidget {
 	get position() {
@@ -179,8 +200,13 @@ class DrawiIo extends api.NoteContextAwareWidget {
 		this.$widget = $(`<style type="text/css">
         div.iframe-drawio{
                 width: 100%;
-    height: 100%;
-}
+                height: 100%;
+        }
+        
+        div.component.note-detail.component img.note-detail-image-view {
+            filter: var(--drawio-preview-filter, none);
+        }
+
         img.note-detail-image-view{        
             transform: none !important;
             width: max-content;
@@ -188,15 +214,19 @@ class DrawiIo extends api.NoteContextAwareWidget {
     height: max-content;
     max-height: 100%;
         } 
-         img.note-detail-image-view.dark {
+        
+img.note-detail-image-view.dark {
   filter: invert(88%) hue-rotate(180deg);
 }
-iframe{
-  z-index: 100;
-}
-div.iframe-drawio.dark{
+
+        iframe{
+            z-index: 100;
+        }
+
+div.iframe-drawio.dark {
   filter: invert(88%) hue-rotate(180deg);
 }
+
   .iframe-drawio      iframe {
 			border:0;
 			right:0;
@@ -244,7 +274,7 @@ div.iframe-drawio.dark{
 		}
 
 		$(document).ready(function () {
-			var ischangeTab = false;
+            var ischangeTab = false;
 			if ($last_image_wrapper != undefined && $last_image_wrapper.length > 0) {
 				window.last_image_wrapper = $last_image_wrapper;
 				$.each($last_image_wrapper.parents(), function (index, value) {

--- a/trilium-drawio.js
+++ b/trilium-drawio.js
@@ -1,31 +1,28 @@
 /*
 trilium-drawio
 https://github.com/SiriusXT/trilium-drawio
-version:0.6
+version:0.7 (patched)
 */
 
 var defaultTheme = "2" //0:light;1:dark;,2:Follow software theme styles
 
 var currentNoteId;
 var themeStyle = getComputedStyle(document.documentElement).getPropertyValue('--theme-style');
-var $last_image_wrapper;//Used to detect tab switching
-var last_noteId;//For detection and switching of new tab pages
 var editor = 'https://embed.diagrams.net/?embed=1&ui=min&spin=1&proto=json&configure=1&libraries=1&noSaveBtn=1&math=1';
 var id_svg_dict = {}
-var noteId = ''
-
+var activeReceiveListeners = {}; // keyed by noteId — supports multiple simultaneous editors
 
 
 function edit(noteId) {
-
+  const editingNoteId = noteId;
   const $wrapper = $('div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper');
 
-  // Guard: if editor already open in this note, don't add another one
+  // Guard: if editor already open in this specific pane, don't add another one
   if ($wrapper.find('div.iframe-drawio').length > 0) {
     return;
   }
 
-  // (optional extra hardening: also kill any stray fullscreen editor)
+  // Kill any stray fullscreen editor
   if ($('body > div.iframe-drawio').length > 0) {
     $('body > div.iframe-drawio').remove();
   }
@@ -50,28 +47,20 @@ function edit(noteId) {
 <div class="drawio-switch-full-screen bx" title="Drawio Switch Full Screen" style=" cursor: pointer; padding: 6px;">
 </div><div class="drawio-save-and-close bx" title="Drawio Close and Exit" style=" cursor: pointer; padding: 6px;">
 </div></div>`);
-	$('div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper div.iframe-drawio .drawio-switch-theme.bx').click(function (event) {//Drawio Switch Theme
+	$('div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper div.iframe-drawio .drawio-switch-theme.bx').click(function (event) {
 		event.stopPropagation();
 		var $iframe_tmp = $("div.component.note-split:not(.hidden-ext) div.note-detail-image-wrapper div.iframe-drawio");
 		if ($iframe_tmp.length > 0) {
-			if ($iframe_tmp.hasClass("dark")) {
-				$iframe_tmp.removeClass("dark");
-			}
-			else {
-				$iframe_tmp.addClass("dark");
-			}
+			if ($iframe_tmp.hasClass("dark")) { $iframe_tmp.removeClass("dark"); }
+			else { $iframe_tmp.addClass("dark"); }
 		}
 		else {
 			const $iframe_tmp = $("body > div.iframe-drawio");
-			if ($iframe_tmp.hasClass("dark")) {
-				$iframe_tmp.removeClass("dark");
-			}
-			else {
-				$iframe_tmp.addClass("dark");
-			}
+			if ($iframe_tmp.hasClass("dark")) { $iframe_tmp.removeClass("dark"); }
+			else { $iframe_tmp.addClass("dark"); }
 		}
 	});
-	$('div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper div.iframe-drawio .drawio-switch-full-screen.bx').click(function (event) {//Drawio full screen
+	$('div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper div.iframe-drawio .drawio-switch-full-screen.bx').click(function (event) {
 		event.stopPropagation();
 		const $iframe_tmp = $("div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper div.iframe-drawio");
 		if ($iframe_tmp.length > 0) {
@@ -85,18 +74,16 @@ function edit(noteId) {
 			$iframe_tmp.css("position", "");
 			$(".tab-row-filler").css("-webkit-app-region", "drag");
 		}
-
 	});
-	//Close and exit button
 	$('div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper div.iframe-drawio .drawio-save-and-close.bx').click(function (event) {
 		event.stopPropagation();
 		close();
 	})
 
-
 	var close = function () {
 		id_svg_dict[noteId] = svg;
 		window.removeEventListener('message', receive);
+		delete activeReceiveListeners[noteId];
 		if ($("div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper div.iframe-drawio").length > 0) {
 			$("div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper div.iframe-drawio").remove();
 		}
@@ -107,20 +94,15 @@ function edit(noteId) {
 		$("div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper img.note-detail-image-view").css("display", "block");
 		var img = $("div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper img.note-detail-image-view");
 		img.attr("src", img.attr("src"));
-		///////////////////////////////////
 		$('div.component.note-split:not(.hidden-ext) div.component.scrolling-container div.note-detail.component div.note-detail-image-wrapper').click(noteId, function () {
 			edit(noteId);
 		});
 	};
 
 	var receive = function (evt) {
-		if (noteId != currentNoteId || div_iframe == undefined || iframe.contentWindow == null) { return; }
+		if (editingNoteId != currentNoteId || div_iframe == undefined || iframe.contentWindow == null) { return; }
 		if (evt.data.length > 0) {
 			var msg = JSON.parse(evt.data);
-
-			// If configure=1 URL parameter is used the application
-			// waits for this message. For configuration options see
-			// https://desk.draw.io/support/solutions/articles/16000058316
 			if (msg.event == 'configure') {
 				iframe.contentWindow.postMessage(JSON.stringify({
 					action: 'configure',
@@ -128,11 +110,9 @@ function edit(noteId) {
 				}), '*');
 			}
 			else if (msg.event == 'init') {
-				iframe.contentWindow.postMessage(JSON.stringify({ action: 'load', autosave: 1, xml: svg, saveAndExit: '0', noExitBtn: '1', saveAndExit: '0' }), '*'); //noExitBtn:'1',saveAndExit: '1',
+				iframe.contentWindow.postMessage(JSON.stringify({ action: 'load', autosave: 1, xml: svg, saveAndExit: '0', noExitBtn: '1' }), '*');
 			}
 			else if (msg.event == 'export') {
-				// Extracts SVG DOM from data URI to enable links
-				//svg = atob(msg.data.substring(msg.data.indexOf(',') + 1));
 				var base64String = msg.data.substring(msg.data.indexOf(',') + 1);
 				const bytes = new Uint8Array(atob(base64String).split('').map(c => c.charCodeAt(0)));
 				const decoder = new TextDecoder('utf-8');
@@ -149,7 +129,6 @@ function edit(noteId) {
 					action: 'export',
 					format: 'xmlsvg', spin: 'Updating page',
 				}), '*');
-
 			}
 			else if (msg.event == 'save') {
 				iframe.contentWindow.postMessage(JSON.stringify({
@@ -163,16 +142,16 @@ function edit(noteId) {
 		}
 	};
 
+	if (activeReceiveListeners[noteId]) { window.removeEventListener('message', activeReceiveListeners[noteId]); }
+	activeReceiveListeners[noteId] = receive;
 	window.addEventListener('message', receive);
 };
-
 
 
 function addClick(noteId, autoEdit) {
   const $wrapper = $('div.component.note-split:not(.hidden-ext) div.component.scrolling-container div.note-detail.component div.note-detail-image-wrapper');
   const $img = $('div.component.note-split:not(.hidden-ext) div.component.scrolling-container div.note-detail.component img.note-detail-image-view');
 
-  // Always (re)bind
   $wrapper.off("click.drawio");
   $wrapper.on("click.drawio", function () { edit(noteId); });
 
@@ -189,68 +168,39 @@ function addClick(noteId, autoEdit) {
 
 
 class DrawiIo extends api.NoteContextAwareWidget {
-	get position() {
-		return 100;
-	}
-	get parentWidget() {
-		return 'center-pane';
-	}
+	get position() { return 100; }
+	static get parentWidget() { return 'center-pane'; }
 
 	doRender() {
 		this.$widget = $(`<style type="text/css">
-        div.iframe-drawio{
-                width: 100%;
-                height: 100%;
+        div.iframe-drawio {
+            width: 100%;
+            height: 100%;
         }
-        
         div.component.note-detail.component img.note-detail-image-view {
             filter: var(--drawio-preview-filter, none);
         }
-
-        img.note-detail-image-view{        
+        img.note-detail-image-view {
             transform: none !important;
             width: max-content;
-    max-width: 100%;
-    height: max-content;
-    max-height: 100%;
-        } 
-        
-img.note-detail-image-view.dark {
-  filter: invert(88%) hue-rotate(180deg);
-}
-
-        iframe{
-            z-index: 100;
+            max-width: 100%;
+            height: max-content;
+            max-height: 100%;
         }
-
-div.iframe-drawio.dark {
-  filter: invert(88%) hue-rotate(180deg);
-}
-
-  .iframe-drawio      iframe {
-			border:0;
-			right:0;
-			bottom:0;
-			width:100%;
-			height:100%
-		}
-       div.iframe-drawio{
-  z-index: 100;
-  border:0;
-			right:0;
-			bottom:0;
-			width:100%;
-			height:100%
-}
- .drawio-switch-theme.bx::before {
-		content: "\\ec34";
-	}
-    .drawio-switch-full-screen.bx::before {
-		content: "\\eaeb";
-	}
-    .drawio-save-and-close.bx::before {
-		content: "\\ec8d";
-	}
+        img.note-detail-image-view.dark {
+            filter: invert(88%) hue-rotate(180deg);
+        }
+        iframe { z-index: 100; }
+        div.iframe-drawio.dark { filter: invert(88%) hue-rotate(180deg); }
+        .iframe-drawio iframe {
+            border: 0; right: 0; bottom: 0; width: 100%; height: 100%;
+        }
+        div.iframe-drawio {
+            z-index: 100; border: 0; right: 0; bottom: 0; width: 100%; height: 100%;
+        }
+        .drawio-switch-theme.bx::before { content: "\\ec34"; }
+        .drawio-switch-full-screen.bx::before { content: "\\eaeb"; }
+        .drawio-save-and-close.bx::before { content: "\\ec8d"; }
 </style>`);
 		return this.$widget;
 	}
@@ -259,6 +209,26 @@ div.iframe-drawio.dark {
 		var noteId = note.noteId;
 		currentNoteId = noteId;
 		var autoEdit = false;
+
+		// Tear down any stale editor scoped to the pane that is transitioning to this note.
+		// Checks each editor individually — leaves editors in other (background) tabs untouched.
+		$("div.note-detail-image-wrapper div.iframe-drawio").each(function () {
+			var $editorPane = $(this).closest("div.component.note-split");
+			// Only remove if this pane is currently the active (visible) one
+			// AND it does not already belong to the note we're navigating TO.
+			var paneIsActive = $editorPane.is(":not(.hidden-ext)");
+			var paneAlreadyShowsThisNote = $editorPane.find("img.note-detail-image-view[src*='" + noteId + "']").length > 0;
+			if (paneIsActive && !paneAlreadyShowsThisNote) {
+				$(this).remove();
+				$editorPane.find(".note-detail-image-wrapper img.note-detail-image-view").css("display", "block");
+			}
+		});
+		// Fullscreen editor escaped to body — always safe to remove
+		if ($("body > div.iframe-drawio").length > 0) {
+			$("body > div.iframe-drawio").remove();
+			$(".tab-row-filler").css("-webkit-app-region", "drag");
+		}
+
 		id_svg_dict[noteId] = (await note.getNoteComplement()).content;
 		if (note.hasLabel("originalFileName") && note.getLabel("originalFileName").value == "drawio.svg" && (await note.getNoteComplement()).content == undefined) {
 			id_svg_dict[noteId] = `<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1px" height="1px" viewBox="-0.5 -0.5 1 1" content="&lt;mxfile host=&quot;app.diagrams.net&quot; modified=&quot;2023-04-29T09:11:12.196Z&quot; agent=&quot;Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/112.0&quot; etag=&quot;fO2zVAtDBdoeKHVc3k6l&quot; version=&quot;21.2.3&quot;&gt;&#xA;  &lt;diagram name=&quot;Page-1&quot; id=&quot;mQcrQwb1aOjnsej_quHy&quot;&gt;&#xA;    &lt;mxGraphModel dx=&quot;1238&quot; dy=&quot;773&quot; grid=&quot;1&quot; gridSize=&quot;10&quot; guides=&quot;1&quot; tooltips=&quot;1&quot; connect=&quot;1&quot; arrows=&quot;1&quot; fold=&quot;1&quot; page=&quot;1&quot; pageScale=&quot;1&quot; pageWidth=&quot;827&quot; pageHeight=&quot;1169&quot; math=&quot;0&quot; shadow=&quot;0&quot;&gt;&#xA;      &lt;root&gt;&#xA;        &lt;mxCell id=&quot;0&quot; /&gt;&#xA;        &lt;mxCell id=&quot;1&quot; parent=&quot;0&quot; /&gt;&#xA;      &lt;/root&gt;&#xA;    &lt;/mxGraphModel&gt;&#xA;  &lt;/diagram&gt;&#xA;&lt;/mxfile&gt;&#xA;" resource="https://app.diagrams.net/?src=about#"><defs/><g/></svg>`;
@@ -273,47 +243,54 @@ div.iframe-drawio.dark {
 			}, [noteId, id_svg_dict[noteId]]);
 		}
 
-		$(document).ready(function () {
-            var ischangeTab = false;
-			if ($last_image_wrapper != undefined && $last_image_wrapper.length > 0) {
-				window.last_image_wrapper = $last_image_wrapper;
-				$.each($last_image_wrapper.parents(), function (index, value) {
-					var truecount = 0;
-					$.each(value.classList, function (index1, classL) {
-						if (classL == "note-split") { truecount += 1; }
-						else if (classL == "hidden-ext") { truecount += 1; }
-					});
-					if (truecount == 2) {
-						ischangeTab = true;
-					}
+		$(document).ready(() => {
+			// ischangeTab: true when this pane is already showing this note (tab switch, not navigation)
+			var ischangeTab = (this.noteId === noteId);
 
-				});
-			}
-			if (last_noteId != undefined && last_noteId == noteId) {
-				ischangeTab = true;
-			}
-			$last_image_wrapper = $("div.component.note-split:not(.hidden-ext) div.scrolling-container.component");
-			last_noteId = noteId;
 			if (!ischangeTab) {
-				if ($("div.component.note-split:not(.hidden-ext) div.note-detail-image-wrapper div.iframe-drawio").length > 0) { $("div.component.note-split:not(.hidden-ext) div.note-detail-image-wrapper div.iframe-drawio").remove(); }
-				if ($("div.component.note-split:not(.hidden-ext) .note-detail-printable.component div.note-detail-image-wrapper img.note-detail-image-view").length > 0) { $("div.component.note-split:not(.hidden-ext) .note-detail-printable.component div.note-detail-image-wrapper img.note-detail-image-view").css("display", "block"); }
+				if ($("div.component.note-split:not(.hidden-ext) div.note-detail-image-wrapper div.iframe-drawio").length > 0) {
+					$("div.component.note-split:not(.hidden-ext) div.note-detail-image-wrapper div.iframe-drawio").remove();
+				}
+				if ($("div.component.note-split:not(.hidden-ext) .note-detail-printable.component div.note-detail-image-wrapper img.note-detail-image-view").length > 0) {
+					$("div.component.note-split:not(.hidden-ext) .note-detail-printable.component div.note-detail-image-wrapper img.note-detail-image-view").css("display", "block");
+				}
 				$('div.component.note-split:not(.hidden-ext) .note-detail-printable.component .note-detail-image-wrapper').off("click");
-				var $img = $('div.component.note-split:not(.hidden-ext) .note-detail-printable.component img.note-detail-image-view');
-				if ($img.length > 0) {
-					if ($img.hasClass('dark')) { $img.removeClass('dark') }
-					if ($img.hasClass('light')) { $img.removeClass('light') }
+				var $imgClean = $('div.component.note-split:not(.hidden-ext) .note-detail-printable.component img.note-detail-image-view');
+				if ($imgClean.length > 0) {
+					if ($imgClean.hasClass('dark')) { $imgClean.removeClass('dark'); }
+					if ($imgClean.hasClass('light')) { $imgClean.removeClass('light'); }
 				}
 			}
+
 			if (note.mime != "image/svg+xml" || id_svg_dict[noteId].indexOf("mxfile") < 0) { return; }
-			setTimeout(function () {
-				if ($("div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper div.iframe-drawio").length > 0) { return; };//When switching tabs, if the iframe is already loaded, return
-				addClick(noteId, autoEdit);
-			}, 10);
+
+			// Trigger ribbon render before polling
 			$("div.ribbon-tab-title.active").click();
 
+			// Poll until the img element exists in the DOM, then bind
+			var pollCount = 0;
+			var pollForImg = setInterval(function () {
+				pollCount++;
+				if (pollCount > 30) { clearInterval(pollForImg); return; }
+				// If an editor iframe is already open in this pane, don't interfere
+				if ($("div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper div.iframe-drawio").length > 0) {
+					clearInterval(pollForImg);
+					return;
+				}
+				var $img = $("div.component.note-split:not(.hidden-ext) div.component.scrolling-container div.note-detail.component img.note-detail-image-view");
+				if ($img.length > 0) {
+					clearInterval(pollForImg);
+					// Ensure the img is visible — may have been hidden by a prior editor session
+					$img.css("display", "block");
+					// Cache-bust src to force a fresh render
+					var src = $img.attr("src");
+					if (src) { $img.attr("src", src + (src.indexOf('?') >= 0 ? '&' : '?') + '_r=' + Date.now()); }
+					addClick(noteId, autoEdit);
+				}
+			}, 100);
 		});
-
 	}
+
 	async entitiesReloadedEvent({ loadResults }) {
 		if (loadResults.isNoteContentReloaded(this.noteId)) {
 			this.refresh();
@@ -321,7 +298,7 @@ div.iframe-drawio.dark {
 	}
 }
 
-module.exports = new DrawiIo();
+module.exports = DrawiIo;
 
 window.onbeforeunload = function () {
 	if ($("div.component.note-split:not(.hidden-ext) .note-detail-image-wrapper div.iframe-drawio").length > 0) {


### PR DESCRIPTION
more robust handling of having multiple instances of the diagram editor opened (different diagrams in different tabs)
more robust handing of preview generation (before, note preview generation would fail if for any reason a diagram editor was opened and improperly closed by navigating away to another note without closing draw.io.

Used AI - Claude (in this second try).

Extensively tested with trilium 0.102.2 on linux and mac. Seems much more solid than before, no need to close trilium or reload the frontend as was the case before. 

